### PR TITLE
fix: entrypoint.sh only contain nginx start up

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,9 +1,9 @@
 server {
     listen 80;
-    server_name https://fastapi-book-project-sx6s.onrender.com;
+    server_name fastapi-book-project-sx6s.onrender.com;
 
     location / {
-        proxy_pass http://127.0.0.1:8000;
+        proxy_pass http://$BACKEND_HOST:$BACKEND_PORT;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
-
-# Replace environment variables in the Nginx configuration file
+# Replace env vars in the template to generate the final config.
 envsubst '$BACKEND_HOST $BACKEND_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
-# Start uvicorn in the background
-uvicorn main:app --host 0.0.0.0 --port 8000 &
-
-# Start Nginx
+# (Removed uvicorn startup because backend service handles that)
+# Start Nginx in the foreground.
 nginx -g 'daemon off;'

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name your-domain.com;
+    server_name fastapi-book-project-sx6s.onrender.com;
 
     location / {
         proxy_pass http://$BACKEND_HOST:$BACKEND_PORT;


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

